### PR TITLE
Use consumers environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,27 @@ const replace = require('broccoli-replace')
 module.exports = {
   name: 'redux',
 
+  /*
+   This method climbs up the hierarchy of addons
+   up to the host application.
+   This prevents previous addons (prior to `this.import`, ca 2.7.0)
+   to break at importing assets when they are used nested in other addons.
+  */
+  _findHost: function () {
+    var current = this
+    var app
+
+    // Keep iterating upward until we don't have a grandparent.
+    // Has to do this grandparent check because at some point we hit the project.
+    do {
+      app = current.app || app
+    } while (current && current.parent && current.parent.parent && (current = current.parent))
+
+    return app
+  },
+
   treeForAddon (tree) {
+    const app = this._findHost()
     const reduxPath = path.dirname(require.resolve('redux/src/index.js'))
     let reduxTree = this.treeGenerator(reduxPath)
 
@@ -17,7 +37,7 @@ module.exports = {
       patterns: [
         {
           match: /process\.env\.NODE_ENV/g,
-          replacement: "'production'"
+          replacement: `"${app.env}"`
         }
       ]
     })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** tree to use consumers current Ember environment.
