### PR TITLE
DEPENDENCY: bump ember-symbol-observable to v1.0.1

### DIFF
--- a/blueprints/ember-redux-shim/index.js
+++ b/blueprints/ember-redux-shim/index.js
@@ -7,7 +7,7 @@ module.exports = {
         return this.addAddonsToProject({
           packages: [
             {name: 'ember-lodash-shim', target: '^2.0.0'},
-            {name: 'ember-symbol-observable', target: '1.0.0'}
+            {name: 'ember-symbol-observable', target: '1.0.1'}
           ]
         })
       })

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ember-load-initializers": "^1.0.0",
     "ember-lodash-shim": "^2.0.0",
     "ember-resolver": "^4.0.0",
-    "ember-symbol-observable": "1.0.0",
+    "ember-symbol-observable": "1.0.1",
     "ember-source": "~2.15.0",
     "ember-cli-shims": "^1.1.0",
     "loader.js": "^4.2.3",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

[DEPENDENCY]: bump ember-symbol-observable to v1.0.1